### PR TITLE
added explanation for blur.mu calculation

### DIFF
--- a/multispot5.cfg
+++ b/multispot5.cfg
@@ -95,6 +95,11 @@ placement=intensity_sampled
 //
 // Spot shape priors. Make sure you SET THIS correctly.
 //
+// calculating a value for blur.mu:
+// 1. temp_sigma = (fwhm_in_nm / pixel_size_in_nm) / (2 * sqrt(2 * ln(2)))
+// 2. blur_sigma = 0.1
+// 3. blur.mu = ln(temp_sigma) + (blur_sigma * blur_sigma)
+//
 
 //Corresponds to 300nm at 100nm per pixel
 blur.mu=0.252148


### PR DESCRIPTION
i got the explanation from `three_B.java` and tested the calculation all the sample parameters (300 nm/100 nm, etc.) which all gave the same values for `blur.mu` as found in the subsequent lines assigning blur.mu  values. hopefully this saves a few people some time.
